### PR TITLE
Convert dependencies file to manifest and sync

### DIFF
--- a/.github/workflows/Recovery Build.yml
+++ b/.github/workflows/Recovery Build.yml
@@ -55,7 +55,9 @@ jobs:
         echo "Manifest Branch: ${{ github.event.inputs.MANIFEST_BRANCH }}"
         echo "Device Tree URL: ${{ github.event.inputs.DEVICE_TREE_URL }}"
         echo "Device Tree Branch: ${{ github.event.inputs.DEVICE_TREE_BRANCH }}"
+        echo "Device Path: ${{ github.event.inputs.DEVICE_PATH }}"
         echo "Device Name: ${{ github.event.inputs.DEVICE_NAME }}"
+        echo "Makefile Name: ${{ github.event.inputs.MAKEFILE_NAME }}"
         echo "Build Target: ${{ github.event.inputs.BUILD_TARGET }}.img"
         echo "::endgroup::"
  
@@ -71,31 +73,13 @@ jobs:
       run: |
         sudo apt update
         sudo apt -y upgrade
-        sudo apt -y install gperf gcc-multilib gcc-10-multilib g++-multilib g++-10-multilib libc6-dev lib32ncurses5-dev x11proto-core-dev libx11-dev tree lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc bc ccache lib32readline-dev lib32z1-dev liblz4-tool libncurses5-dev libsdl1.2-dev libwxgtk3.0-dev libxml2 lzop pngcrush schedtool squashfs-tools imagemagick libbz2-dev lzma ncftp python qemu-user-static libstdc++-10-dev
-        sudo apt-get update
-        sudo apt-get -y install --reinstall build-essential
+        sudo apt -y install gperf gcc-multilib gcc-10-multilib g++-multilib g++-10-multilib libc6-dev lib32ncurses5-dev x11proto-core-dev libx11-dev tree lib32z-dev libgl1-mesa-dev libxml2-utils xsltproc bc ccache lib32readline-dev lib32z1-dev liblz4-tool libncurses5-dev libsdl1.2-dev libwxgtk3.0-dev libxml2 lzop pngcrush schedtool squashfs-tools imagemagick libbz2-dev lzma ncftp qemu-user-static libstdc++-10-dev python
 
-
-    - name: Install OpenJDK 7
-      if: |
-        github.event.inputs.MANIFEST_BRANCH == 'twrp-5.1'
-        || github.event.inputs.MANIFEST_BRANCH == 'twrp-6.0'
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '7'
-
-    - name: Install OpenJDK 8
-      if: |
-        github.event.inputs.MANIFEST_BRANCH != 'twrp-5.1'
-        && github.event.inputs.MANIFEST_BRANCH != 'twrp-6.0'
+    - name: Install OpenJDK
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
         java-version: '8'
-
-    - name: Verify Java Install
-      run: java -version
 
     - name: Setup SSH Keys
       if: ${{ startsWith(github.event.inputs.MANIFEST_URL, 'git@github.com') }}
@@ -114,11 +98,10 @@ jobs:
         mkdir ~/bin
         curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
         chmod a+x ~/bin/repo
-        export PATH=~/bin:$PATH
+        sudo ln -sf ~/bin/repo /usr/bin/repo
       
     - name: Initialize repo
       run: |
-        PATH=~/bin:$PATH
         mkdir workspace
         cd workspace
         echo "::set-output name=pwd::$(pwd)"
@@ -129,57 +112,56 @@ jobs:
           
     - name: Repo Sync
       run: |
-        PATH=~/bin:$PATH
-        cd workspace
-        repo sync -j$(nproc --all) -f --force-sync
-        ls -al
+        repo sync -j$(nproc --all) --force-sync
+      working-directory: workspace
       
     - name: Clone device tree
       run: |
-        PATH=~/bin:$PATH
-        cd ${{ steps.pwd.outputs.pwd }}
         git clone ${{ github.event.inputs.DEVICE_TREE_URL }} -b ${{ github.event.inputs.DEVICE_TREE_BRANCH }} ./${{ github.event.inputs.DEVICE_PATH }}
+      working-directory: ${{ steps.pwd.outputs.pwd }}
 
     - name: Clone common tree
       if: |
         github.event.inputs.COMMON_TREE_URL != null
         && github.event.inputs.COMMON_PATH != null
       run: |
-        PATH=~/bin:$PATH
-        cd ${{ steps.pwd.outputs.pwd }}
         git clone ${{ github.event.inputs.COMMON_TREE_URL }} -b ${{ github.event.inputs.DEVICE_TREE_BRANCH }} ./${{ github.event.inputs.COMMON_PATH }}
+      working-directory: ${{ steps.pwd.outputs.pwd }}
+
+    - name: Check Build Tree
+      uses: haya14busa/action-cond@v1
+      id: buildtree
+      with:
+        cond: ${{ github.event.inputs.MANIFEST_BRANCH == 'twrp-11' || github.event.inputs.MANIFEST_BRANCH == 'twrp-12.1' }}
+        if_true: twrp
+        if_false: omni
+
+    - name: Sync Device Dependencies
+      run: |
+        bash ${GITHUB_WORKSPACE}/scripts/convert.sh ${{ github.event.inputs.DEVICE_PATH }}/${{ steps.buildtree.outputs.value }}.dependencies
+        repo sync -j$(nproc --all)
+      working-directory: ${{ steps.pwd.outputs.pwd }}
+      continue-on-error: true
 
     - name: Set Swap Space
       uses: pierotofy/set-swap-space@master
       with:
         swap-size-gb: 12
 
-    - name: Check Build Branch - Step 1
+    - name: Check Build Branch
       if: ${{ github.event.inputs.MANIFEST_BRANCH == 'twrp-12.1' }}
       run: |
-        PATH=~/bin:$PATH
-        cd ${{ steps.pwd.outputs.pwd }}
         source build/envsetup.sh
         repopick 5405 5540
-
-    - name: Check Build Branch - Step 2
-      if: ${{ github.event.inputs.MANIFEST_BRANCH == 'twrp-5.1' }}
-      run: |
-        PATH=~/bin:$PATH
-        cd ${{ steps.pwd.outputs.pwd }}
-        cd bootable/recovery
-        git fetch https://gerrit.twrp.me/android_bootable_recovery refs/changes/29/5729/1 && git cherry-pick FETCH_HEAD
+      working-directory: ${{ steps.pwd.outputs.pwd }}
 
     - name: Building recovery
       run: |
-        PATH=~/bin:$PATH
-        cd ${{ steps.pwd.outputs.pwd }}
         source build/envsetup.sh
-        lunch ${{ github.event.inputs.MAKEFILE_NAME }}-eng
         export ALLOW_MISSING_DEPENDENCIES=true
-        make clean
-        make ${{ github.event.inputs.BUILD_TARGET }}image -j$(nproc --all)        
-      
+        lunch ${{ github.event.inputs.MAKEFILE_NAME }}-eng && make clean && make ${{ github.event.inputs.BUILD_TARGET }}image -j$(nproc --all)
+      working-directory: ${{ steps.pwd.outputs.pwd }}
+
     - name: Upload to Release
       uses: softprops/action-gh-release@v1
       with:

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+if [ -n "$1" ] && [ -e $1 ]; then
+	file=$1
+else
+	echo " ** Input File : $1 does not exist"
+	echo " ** Please specify the correct dependencies file"
+	echo " ** Usage : bash <path-to-script> <path-to-dependencies-file> [<path-to-local-manifest>]"
+	exit 1
+fi
+
+if [ -n "$2" ]; then
+	manifest_path="$2"
+elif [ -e .repo ]; then
+	mkdir -p .repo/local_manifests
+	manifest_path=".repo/local_manifests/roomservice.xml"
+else
+	echo " ** Manifest file to create not specified."
+	echo " ** And .repo folder does not exist in $PWD"
+	echo " ** Either run the script from root of your source or specify a custom path+filename"
+	echo " ** Usage : bash <path-to-script> <path-to-dependencies-file> [<path-to-local-manifest>]"
+	exit 1
+fi
+
+
+if [ -e $manifest_path ]; then
+	sed -i 's@</manifest>@@g' $manifest_path
+else
+	echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" > $manifest_path
+	echo "<manifest>" >> $manifest_path
+fi
+
+vars=( "remote" "repository" "target_path" "branch" "revision")
+
+for i in ${!vars[@]} ; do
+	value=$(grep "${vars[$i]}" "$file" | cut -d '"' -f4)
+	if [ "$value" != "" ]; then
+		declare -a ${vars[$i]}"_val"="( $value )"
+	fi
+done
+
+for i in {0..5}; do
+	if [ "${repository_val[$i]}" != "" ] && [ "${target_path_val[$i]}" != "" ]; then
+		target_path="path=\"${target_path_val[$i]}\""
+		repository=" name=\"${repository_val[$i]}\""
+		if [ "${remote_val[$i]}" != "" ]; then
+			remote_for_repo=" remote=\"${remote_val[$i]}\""
+		fi
+		if [ "${branch_val[$i]}" != "" ]; then
+			revision=" revision=\"${branch_val[$i]}\""
+		elif [ "${revision_val[$i]}" != "" ]; then
+			revision=" revision=\"${revision_val[$i]}\""
+		fi
+		echo "  <project $target_path$repository$remote_for_repo$revision />" >> $manifest_path
+	fi
+done
+
+echo "</manifest>" >> $manifest_path


### PR DESCRIPTION
Add script to convert dependencies file. Thanks to @Yilliee
for providing the script!

If dependency file doesn't exist, then report error and
continue to next step (continue-on-error)

Use conditional based on branch to identify expected
name of dependency file

Additional updates and cleanup, including:
- Remove branch check for 5.1 (upstream merged)
- Replace "cd" commands with working-directory
- Remove PATH references
- Symlink ~/bin/repo to /usr/bin so automatically included
  in PATH
- Clean up repo command (-f is deprecated)
- Only build JDK 8 (JDK 7 not needed) and remove version check
- Display more build parameters (user environment variables)